### PR TITLE
Update readme and changelog for #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2020-05-10
+
+### Fixed
+
+- GitHub Actions does not support sequences as input
+
+## [1.3.0] - 2022-05-09
+
+### Added
+
+- Add support for ignores (#1)
+
 ## [1.2.0] - 2020-05-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,5 +83,6 @@ For each new advisory (including informal) an issue will be created:
 | Name        | Required | Description                                                                | Type   | Default |
 | ------------| -------- | ---------------------------------------------------------------------------| ------ | --------|
 | `token`     | ✓        | [GitHub token], usually a `${{ secrets.GITHUB_TOKEN }}`                    | string |         |
+| `ignore`    |          | Comma-separated list of advisory ids to ignore                             | string |         |
 
 [GitHub token]: https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token


### PR DESCRIPTION
Dates for the releases in the changelog are taken from the non- squashed commits of <https://github.com/rustsec/audit-check/pull/1>.